### PR TITLE
[FIX] Support for >100 participants (Issue #5)

### DIFF
--- a/webapp/view/Detail.view.xml
+++ b/webapp/view/Detail.view.xml
@@ -25,7 +25,7 @@
 				</items>
 			</IconTabBar>
 			<Table id="lineItemsList" width="auto" items="{Participants}" updateFinished="onListUpdateFinished"
-				noDataText="{i18n>detailLineItemTableNoDataText}" busyIndicatorDelay="{detailView>/lineItemTableDelay}" class="sapUiResponsiveMargin">
+				noDataText="{i18n>detailLineItemTableNoDataText}" busyIndicatorDelay="{detailView>/lineItemTableDelay}" growing="true" growingThreshold="100" class="sapUiResponsiveMargin">
 				<headerToolbar>
 					<Toolbar id="lineItemsToolbar">
 						<Title id="lineItemsHeader" text="{detailView>/lineItemListTitle}"/>


### PR DESCRIPTION
Fix for the issue that if we have over 100 participants, only the first 100 will be shown.
As it's rare that we will have that many at the moment, set the growing threshold to 100, so normally all are listed already. If we have more though, the Table can grow with 100 each time now.