### PR TITLE
Added Invalid SAML Error handling

### DIFF
--- a/webapp/controller/ErrorHandler.js
+++ b/webapp/controller/ErrorHandler.js
@@ -22,10 +22,24 @@ sap.ui.define([
 
 				this._oModel.attachMetadataFailed(function (oEvent) {
 					// Do we have to login?
-					if (oEvent.mParameters.response.headers["com.sap.cloud.security.login"] === "login-request") {
+					var oParams = oEvent.getParameters();
+					if (oParams.response.headers["com.sap.cloud.security.login"] === "login-request") {
 						window.location.reload();
 					}
-					var oParams = oEvent.getParameters();
+
+					//Relogin in a seperate Window and close it again, typed in information by the user is kept this way
+					var sCacheControl = oParams.response.headers["cache-control"] || "";
+					var bSamlInvalid = sCacheControl.includes("must-revalidate");
+					if (bSamlInvalid) {
+						var wnd = window.open("about:blank", '_blank', 'toolbar=no,status=no,menubar=no,scrollbars=no,resizable=no,left=10000, top=10000, width=10, height=10, visible=none', '');
+						wnd.blur();
+				        wnd.document.write(oParams.response.responseText);
+				        wnd.document.close();
+				        setTimeout(function() {
+						    wnd.close();
+							}, 3000);
+						}
+					
 					this._showMetadataError(oParams.response);
 				}, this);
 


### PR DESCRIPTION
Hi Gregor,
hier der Pull Request bezüglich der Reauthentifizierung. Das Ziel war, den Workflow der Mitarbeiter bei der Reauthentifizierung nicht zu beeinträchtigen und eingetragene Daten bzw. hochgeladene Bilder beizubehalten. Ein einfacher Reload der Seite würde diese Daten verwerfen. Aus dem Grund wird ein neues Fenster geöffnet, welches sich nach 3 Sekunden von selbst wieder schließt (ähnlich wie der Session Timeout beim SCP Cockpit).
Eleganter wär es jedoch, das Fenster automatisch zu schließen, sobald die Authentifizierung vollendet ist (unabhängig von einem festen Timeout). Außerdem könnte das Fenster direkt in den Hintergrund geschoben werden, sodass der User so wenig wie möglich mitbekommt. Dies sehen wir als weitere Optimierungsmöglichkeiten an.
Viele Grüße,
Armin